### PR TITLE
Add support for using a HTTPS catalog URL for arbitrary catalogs

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -56,13 +56,29 @@ spec:
           masked: true
 ```
 
-### External cluster catalog
+### External cluster catalog via SSH
 
-If the cluster catalog is not hosted on the same GitLab instance as the tenant repo, you can specify an SSH key which has access to the cluster catalog and the relevant known hosts entry via CI/CD variables on the tenant repo:
+If the cluster catalog is hosted externally and can be cloned via SSH, you can specify an SSH key which has access to the cluster catalog and the relevant known hosts entry via CI/CD variables on the tenant repo:
 
 1. Create a CI/CD variable named `SSH_PRIVATE_KEY` containing the SSH private key.
 1. Create a CI/CD varaible named `SSH_KNOWN_HOSTS` containing the know hosts entry.
 1. (optional) Create a CI/CD variable named `SSH_CONFIG` containing any required SSH configuration.
+
+### External cluster catalog via HTTPS
+
+If the cluster catalog is hosted externally and must be cloned via HTTPS, you can configure HTTPS credentials via CI/CD variables on the tenant repo:
+
+1. Create a CI/CD variable named `ACCESS_USER_CLUSTERNAME` where `CLUSTERNAME` is the Project Syn ID of the cluster. 
+   Set this variable's value to the username used to access the catalog repo.
+1. Create a CI/CD variable named `ACCESS_TOKEN_CLUSTERNAME` where `CLUSTERNAME` is the Project Syn ID of the cluster.
+   Set this variable's value to the password or token used to access the catalog repo.
+
+> [!NOTE]
+> To make this work, the Project Syn cluster must be configured to provide its `catalogURL` with a `https://` prefix.
+
+> [!TIP]
+> The variable `ACCESS_USER_CLUSTERNAME` is optional.
+> If it's not provided, the CI pipeline will fallback to username `token`.
 
 ### Test new pipeline generation image
 

--- a/gitlab/tests/external-catalog.env
+++ b/gitlab/tests/external-catalog.env
@@ -1,2 +1,2 @@
 CLUSTERS="c-cluster-id-1234 c-cluster-id-5678 c-cluster-id-1111"
-CLUSTER_CATALOG_URLS="c-cluster-id-1234=ssh://git@git.vshn.net/cluster-catalogs/c-cluster-id-1234.git c-cluster-id-5678=ssh://git@git.example.com/cluster-catalogs/c-cluster-id-5678.git c-cluster-id-1111=https://user:pass@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5"
+CLUSTER_CATALOG_URLS="c-cluster-id-1234=ssh://git@git.vshn.net/cluster-catalogs/c-cluster-id-1234.git c-cluster-id-5678=ssh://git@git.example.com/cluster-catalogs/c-cluster-id-5678.git c-cluster-id-1111=https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5"

--- a/gitlab/tests/external-catalog.env
+++ b/gitlab/tests/external-catalog.env
@@ -1,2 +1,2 @@
 CLUSTERS="c-cluster-id-1234 c-cluster-id-5678 c-cluster-id-1111"
-CLUSTER_CATALOG_URLS="c-cluster-id-1234=ssh://git@git.vshn.net/cluster-catalogs/c-cluster-id-1234.git c-cluster-id-5678=ssh://git@git.example.com/cluster-catalogs/c-cluster-id-5678.git c-cluster-id-1111=https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5"
+CLUSTER_CATALOG_URLS="c-cluster-id-1234=ssh://git@git.vshn.net/cluster-catalogs/c-cluster-id-1234.git c-cluster-id-5678=ssh://git@git.example.com/cluster-catalogs/c-cluster-id-5678.git c-cluster-id-1111=https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git"

--- a/gitlab/tests/golden/external-catalog.yml
+++ b/gitlab/tests/golden/external-catalog.yml
@@ -21,7 +21,7 @@
       ],
       "script": [
          "git config --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
-         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5",
+         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
          "/usr/local/bin/entrypoint.sh commodore catalog compile --tenant-repo-revision-override $CI_COMMIT_SHA c-cluster-id-1111",
          "(cd catalog/ && git --no-pager diff --staged --output ../diff.txt)"
       ],
@@ -48,7 +48,7 @@
       ],
       "script": [
          "git config --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
-         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5",
+         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
          "/usr/local/bin/entrypoint.sh commodore catalog compile --push c-cluster-id-1111"
       ],
       "stage": "deploy",

--- a/gitlab/tests/golden/external-catalog.yml
+++ b/gitlab/tests/golden/external-catalog.yml
@@ -21,6 +21,7 @@
       ],
       "script": [
          "git config --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
+         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5",
          "/usr/local/bin/entrypoint.sh commodore catalog compile --tenant-repo-revision-override $CI_COMMIT_SHA c-cluster-id-1111",
          "(cd catalog/ && git --no-pager diff --staged --output ../diff.txt)"
       ],
@@ -47,6 +48,7 @@
       ],
       "script": [
          "git config --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
+         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git5",
          "/usr/local/bin/entrypoint.sh commodore catalog compile --push c-cluster-id-1111"
       ],
       "stage": "deploy",


### PR DESCRIPTION
This PR introduces logic which configures a [Git `insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) which injects the CI variables `ACCESS_USER_<cluster_id>` (which is optional and falls back to `token` if it's not set) and `ACCESS_TOKEN_<cluster_id>` (which must be present) for catalog URLs that are HTTPS on Lieutenant.

For example, the change will run the following `git` command for catalog URL "https://git.example.com/c-cluster-id-1234.git" for clustesr `c-cluster-id-1234`:

```
git config --global \
  url."https://${ACCESS_USER_c_cluster_id_1234:-token}:${ACCESS_TOKEN_c_cluster_id_1234}@git.example.com/c-cluster-id-1234.git".insteadOf \
  https://git.example.com/c-cluster-id-1234.git
```

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the following labels so it shows up
      in the correct changelog section:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
