### PR TITLE
Fix `insteadOf` for HTTPS catalog repo

### DIFF
--- a/gitlab/tests/golden/external-catalog.yml
+++ b/gitlab/tests/golden/external-catalog.yml
@@ -21,7 +21,8 @@
       ],
       "script": [
          "git config --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
-         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
+         "git config --add --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
+         "git config --add --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf ssh://git@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
          "/usr/local/bin/entrypoint.sh commodore catalog compile --tenant-repo-revision-override $CI_COMMIT_SHA c-cluster-id-1111",
          "(cd catalog/ && git --no-pager diff --staged --output ../diff.txt)"
       ],
@@ -48,7 +49,8 @@
       ],
       "script": [
          "git config --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
-         "git config --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
+         "git config --add --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf https://git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
+         "git config --add --global url.\"https://${ACCESS_USER_c_cluster_id_1111:-token}:${ACCESS_TOKEN_c_cluster_id_1111}@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git\".insteadOf ssh://git@git.vshn.net/cluster-catalogs/c-cluster-id-1111.git",
          "/usr/local/bin/entrypoint.sh commodore catalog compile --push c-cluster-id-1111"
       ],
       "stage": "deploy",


### PR DESCRIPTION
We need to configure an additional `insteadOf` for the `ssh://git@` variant of a HTTPS catalog URL since Commodore will optimistically rewrite all HTTPS Git URLs to have their `ssh://git@` equivalent as the push URL to make local component development easier.

Fixes #11 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the following labels so it shows up
      in the correct changelog section:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
- [x] Link this PR to related issues or PRs.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
