### PR TITLE
Abort `render-pipeline` when we get a `null` catalog URL

### DIFF
--- a/gitlab/bin/step-render-pipeline
+++ b/gitlab/bin/step-render-pipeline
@@ -4,6 +4,10 @@ set -e -u -x
 cluster_catalog_urls=""
 for c in ${CLUSTERS}; do
   r=$(curl -sH"Authorization: Bearer ${COMMODORE_API_TOKEN}" "${COMMODORE_API_URL}/clusters/${c}" | jq -r .gitRepo.url)
+  if [ "$r" = "null" ]; then
+    echo "Got 'null' for catalog URL fo cluster ${c}, aborting..."
+    exit 1
+  fi
   cluster_catalog_urls="${cluster_catalog_urls}${c}=${r} "
 done
 


### PR DESCRIPTION
Abort `render-pipeline` script when Lieutenant API returns no catalog URL for a cluster. This makes the failure mode more obvious than unexpected failing compile jobs for some clusters (usually with an error like "fatal: unable to access 'catalog repo': The requested URL returned error: 403".

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the following labels so it shows up
      in the correct changelog section:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
