### PR TITLE
Support catalog URLs with custom SSH ports

### DIFF
--- a/gitlab/commodore-compile.jsonnet
+++ b/gitlab/commodore-compile.jsonnet
@@ -28,7 +28,7 @@ local gitInsteadOf(cluster) =
   local cluster_access_token = '${ACCESS_TOKEN_%s}' % std.strReplace(cluster, '-', '_');
   local cluster_access_user = '${ACCESS_USER_%s:-token}' % std.strReplace(cluster, '-', '_');
   local cluster_repo = cluster_catalog_urls[cluster];
-  local ssh_gitlab = 'ssh://git@%s/' % gitlab_ssh_host;
+  local ssh_gitlab = 'ssh://git@%s' % gitlab_ssh_host;
   local catalog_path = if std.startsWith(cluster_repo, ssh_gitlab) then
     // prefix ssh://git@<host> 0 == ssh, 1 == '', 2 == <host>
     std.join('/', std.split(cluster_repo, '/')[3:]);

--- a/gitlab/tests/custom-ssh-port.env
+++ b/gitlab/tests/custom-ssh-port.env
@@ -1,0 +1,2 @@
+CLUSTERS="c-cluster-id-1234"
+CLUSTER_CATALOG_URLS="c-cluster-id-1234=ssh://git@git.vshn.net:2222/cluster-catalogs/c-cluster-id-1234.git"

--- a/gitlab/tests/golden/custom-ssh-port.yml
+++ b/gitlab/tests/golden/custom-ssh-port.yml
@@ -1,0 +1,65 @@
+{
+   "c-cluster-id-1234_compile": {
+      "artifacts": {
+         "expire_in": "1 week",
+         "paths": [
+            "diff.txt"
+         ]
+      },
+      "before_script": [
+         "install --directory --mode=0700 ~/.ssh",
+         "echo \"$SSH_KNOWN_HOSTS\" >> ~/.ssh/known_hosts",
+         "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
+      ],
+      "image": {
+         "name": "docker.io/projectsyn/commodore:v1.32.3"
+      },
+      "rules": [
+         {
+            "if": "$CI_COMMIT_REF_NAME != $CI_DEFAULT_BRANCH"
+         }
+      ],
+      "script": [
+         "git config --add --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
+         "git config --add --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}${CI_SERVER_SHELL_SSH_PORT:+:${CI_SERVER_SHELL_SSH_PORT}}",
+         "git config --add --global url.\"https://gitlab-ci-token:${ACCESS_TOKEN_c_cluster_id_1234}@git.vshn.net:80/cluster-catalogs/c-cluster-id-1234.git\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}/cluster-catalogs/c-cluster-id-1234.git",
+         "git config --add --global url.\"https://gitlab-ci-token:${ACCESS_TOKEN_c_cluster_id_1234}@git.vshn.net:80/cluster-catalogs/c-cluster-id-1234.git\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}${CI_SERVER_SHELL_SSH_PORT:+:${CI_SERVER_SHELL_SSH_PORT}}/cluster-catalogs/c-cluster-id-1234.git",
+         "/usr/local/bin/entrypoint.sh commodore catalog compile --tenant-repo-revision-override $CI_COMMIT_SHA c-cluster-id-1234",
+         "(cd catalog/ && git --no-pager diff --staged --output ../diff.txt)"
+      ],
+      "stage": "build",
+      "variables": {
+         "KUBERNETES_CPU_LIMIT": "2",
+         "KUBERNETES_CPU_REQUEST": "800m",
+         "KUBERNETES_MEMORY_LIMIT": "3Gi"
+      }
+   },
+   "c-cluster-id-1234_deploy": {
+      "before_script": [
+         "install --directory --mode=0700 ~/.ssh",
+         "echo \"$SSH_KNOWN_HOSTS\" >> ~/.ssh/known_hosts",
+         "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
+      ],
+      "image": {
+         "name": "docker.io/projectsyn/commodore:v1.32.3"
+      },
+      "rules": [
+         {
+            "if": "$CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH"
+         }
+      ],
+      "script": [
+         "git config --add --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}",
+         "git config --add --global url.\"https://gitlab-ci-token:${CI_JOB_TOKEN}@git.vshn.net:80\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}${CI_SERVER_SHELL_SSH_PORT:+:${CI_SERVER_SHELL_SSH_PORT}}",
+         "git config --add --global url.\"https://gitlab-ci-token:${ACCESS_TOKEN_c_cluster_id_1234}@git.vshn.net:80/cluster-catalogs/c-cluster-id-1234.git\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}/cluster-catalogs/c-cluster-id-1234.git",
+         "git config --add --global url.\"https://gitlab-ci-token:${ACCESS_TOKEN_c_cluster_id_1234}@git.vshn.net:80/cluster-catalogs/c-cluster-id-1234.git\".insteadOf ssh://git@${CI_SERVER_SHELL_SSH_HOST}${CI_SERVER_SHELL_SSH_PORT:+:${CI_SERVER_SHELL_SSH_PORT}}/cluster-catalogs/c-cluster-id-1234.git",
+         "/usr/local/bin/entrypoint.sh commodore catalog compile --push c-cluster-id-1234"
+      ],
+      "stage": "deploy",
+      "variables": {
+         "KUBERNETES_CPU_LIMIT": "2",
+         "KUBERNETES_CPU_REQUEST": "800m",
+         "KUBERNETES_MEMORY_LIMIT": "3Gi"
+      }
+   }
+}


### PR DESCRIPTION
Fixes #28 to correctly detect catalog URLs with a custom port which are hosted on the local GitLab.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the following labels so it shows up
      in the correct changelog section:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`
- [x] Link this PR to related issues or PRs.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
