### PR TITLE
Improve error message when CI pipeline generation receives zero clusters

### DIFF
--- a/gitlab/commodore-compile.jsonnet
+++ b/gitlab/commodore-compile.jsonnet
@@ -18,7 +18,7 @@ local gitlab_ssh_host = std.extVar('server_ssh_host');
 // unset even though GitLab currently unconditionally sets the variable
 // `CI_SERVER_SHELL_SSH_PORT`.
 local ci_ssh_hostport = '${CI_SERVER_SHELL_SSH_HOST}${CI_SERVER_SHELL_SSH_PORT:+:${CI_SERVER_SHELL_SSH_PORT}}';
-local clusters = std.split(std.extVar('clusters'), ' ');
+local clusters = std.filter(function(it) it != '', std.split(std.extVar('clusters'), ' '));
 local cluster_catalog_urls = to_array('cluster_catalog_urls');
 local memory_limits = to_array('memory_limits');
 local cpu_limits = to_array('cpu_limits');
@@ -181,4 +181,7 @@ local deploy =
     for x in clusters
   };
 
-compile + deploy
+if std.length(clusters) == 0 then
+  error 'Commodore CI pipeline generator expects at least one cluster, got zero'
+else
+  compile + deploy


### PR DESCRIPTION
Originally, we tried this PR by gracefully degrading to emitting an empty file (`{ }`). However, after testing, we've discovered that this just makes the downstream fail because GitLab doesn't accept an empty file as a valid CI definition.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the following labels so it shows up
      in the correct changelog section:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
