### PR TITLE
Add basic validation for CI job requests & limits

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -119,7 +119,7 @@ The following options can be configured as CI/CD variables when the GitLab insta
 The job generator expects that each of these variables has space-separated entries of the form `c-cluster-id-1234=value` if it's present.
 
 > [!TIP]
-> The Job generator raises an error if a CI job's K8s resource limits are > invalid (i.e. limit < request).
+> The Job generator raises an error if a CI job's K8s resource limits are invalid (i.e. limit < request).
 > However, CI jobs may fail to run if you set requests or limits that are higher than the GitLab K8s CI runner's maximum allowed request or limit overrides.
 
 Example:

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -118,10 +118,9 @@ The following options can be configured as CI/CD variables when the GitLab insta
 
 The job generator expects that each of these variables has space-separated entries of the form `c-cluster-id-1234=value` if it's present.
 
-> [!NOTE]
-> The Job generator doesn't validate custom requests and limits.
-> The CI job for a cluster will fail run if you set higher requests than limits for the cluster.
-> CI jobs also will fail to run if you set requests or limits that are higher than the GitLab K8s CI runner's maximum allowed request or limit overrides.
+> [!TIP]
+> The Job generator raises an error if a CI job's K8s resource limits are > invalid (i.e. limit < request).
+> However, CI jobs may fail to run if you set requests or limits that are higher than the GitLab K8s CI runner's maximum allowed request or limit overrides.
 
 Example:
 

--- a/gitlab/commodore-compile.jsonnet
+++ b/gitlab/commodore-compile.jsonnet
@@ -103,7 +103,7 @@ local gitInsteadOf(cluster) =
     'git config --add --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@%(gitlab_fqdn)s".insteadOf ssh://git@%(ssh_hostport)s' % gitlab_params,
   ] + catalogInsteadOf;
 
-local cpu_limit(cluster) = std.get(cpu_limits, cluster, '2');
+local read_cpu_limit(cluster) = std.get(cpu_limits, cluster, '2');
 
 // K8s quantity parser.
 // Supported suffices as listed in `kubectl explain pod.spec.containers.resources.requests`.
@@ -155,13 +155,50 @@ local parseK8sQuantity(q) =
 // rounding down to the next nearest integer, clamped at 1.
 local proc_count(cluster) =
   if std.extVar('commodore_proc_count_from_cpu_limit') != '' then (
-    local cl = parseK8sQuantity(cpu_limit(cluster));
+    local cl = parseK8sQuantity(read_cpu_limit(cluster));
     if cl >= 1 then std.floor(cl) else 1
   ) else
     // Commodore auto-selects the number of worker processes when the value of
     // the flag/envvar is 0. This matches the behavior of Commodore v1.33.1
     // and older.
     0;
+
+local job_vars(cluster) =
+  local memory_limit = std.get(memory_limits, cluster, '3Gi');
+  local memory_request = std.get(memory_requests, cluster, '3Gi');
+  local cpu_limit = read_cpu_limit(cluster);
+  local cpu_request = std.get(cpu_requests, cluster, '800m');
+  local memerr =
+    if parseK8sQuantity(memory_request) <= parseK8sQuantity(memory_limit) then
+      ''
+    else
+      'memory limit (%(ml)s) smaller than memory request (%(mr)s)' % {
+        ml: memory_limit,
+        mr: memory_request,
+      };
+  local cpuerr =
+    if parseK8sQuantity(cpu_request) <= parseK8sQuantity(cpu_limit) then
+      ''
+    else
+      'CPU limit (%(cpu_limit)s) smaller than CPU request (%(cpu_request)s)' % {
+        cpu_limit: cpu_limit,
+        cpu_request: cpu_request,
+      };
+  assert
+    memerr == '' && cpuerr == ''
+    : 'Invalid CI job config for cluster %(cluster)s: %(memerr)s%(both)s%(cpuerr)s' % {
+      cluster: cluster,
+      memerr: memerr,
+      cpuerr: cpuerr,
+      both: if memerr == '' || cpuerr == '' then '' else ' and ',
+    };
+  {
+    KUBERNETES_MEMORY_LIMIT: memory_limit,
+    KUBERNETES_MEMORY_REQUEST: memory_request,
+    KUBERNETES_CPU_LIMIT: cpu_limit,
+    KUBERNETES_CPU_REQUEST: cpu_request,
+    COMMODORE_CATALOG_COMPILE_PROCESSES: proc_count(cluster),
+  };
 
 local compile_job(cluster) =
   {
@@ -170,14 +207,7 @@ local compile_job(cluster) =
       {
         name: commodore_image,
       },
-    variables:
-      {
-        KUBERNETES_MEMORY_LIMIT: std.get(memory_limits, cluster, '3Gi'),
-        KUBERNETES_MEMORY_REQUEST: std.get(memory_requests, cluster, '3Gi'),
-        KUBERNETES_CPU_LIMIT: cpu_limit(cluster),
-        KUBERNETES_CPU_REQUEST: std.get(cpu_requests, cluster, '800m'),
-        COMMODORE_CATALOG_COMPILE_PROCESSES: proc_count(cluster),
-      },
+    variables: job_vars(cluster),
     before_script:
       [
         'install --directory --mode=0700 ~/.ssh',
@@ -206,14 +236,7 @@ local compile_job(cluster) =
 local deploy_job(cluster) =
   {
     stage: 'deploy',
-    variables:
-      {
-        KUBERNETES_MEMORY_LIMIT: std.get(memory_limits, cluster, '3Gi'),
-        KUBERNETES_MEMORY_REQUEST: std.get(memory_requests, cluster, '3Gi'),
-        KUBERNETES_CPU_LIMIT: cpu_limit(cluster),
-        KUBERNETES_CPU_REQUEST: std.get(cpu_requests, cluster, '800m'),
-        COMMODORE_CATALOG_COMPILE_PROCESSES: proc_count(cluster),
-      },
+    variables: job_vars(cluster),
     image:
       {
         name: commodore_image,


### PR DESCRIPTION
Extend the Job generator to raise an error if a CI job's resource request is larger than the corresponding limit.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the following labels so it shows up
      in the correct changelog section:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
