### PR TITLE
Pull Commodore image from `ghcr.io`

### DIFF
--- a/gitlab/commodore-compile.jsonnet
+++ b/gitlab/commodore-compile.jsonnet
@@ -1,5 +1,5 @@
 local commodore_version = 'v1.34.0';
-local commodore_image = 'docker.io/projectsyn/commodore:' + commodore_version;
+local commodore_image = 'ghcr.io/projectsyn/commodore:' + commodore_version;
 
 local to_array(param) = std.foldl(
   function(obj, elem)

--- a/gitlab/commodore-pipeline.yml
+++ b/gitlab/commodore-pipeline.yml
@@ -36,7 +36,7 @@ yamllint:
 commodore-lint:
   stage: lint
   image:
-    name: docker.io/projectsyn/commodore:latest
+    name: ghcr.io/projectsyn/commodore:latest
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
   script:
     - commodore inventory lint .

--- a/gitlab/tests/golden/custom-ssh-port.yml
+++ b/gitlab/tests/golden/custom-ssh-port.yml
@@ -12,7 +12,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -43,7 +43,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {

--- a/gitlab/tests/golden/default.yml
+++ b/gitlab/tests/golden/default.yml
@@ -12,7 +12,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -43,7 +43,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {

--- a/gitlab/tests/golden/external-catalog.yml
+++ b/gitlab/tests/golden/external-catalog.yml
@@ -12,7 +12,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -43,7 +43,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -79,7 +79,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -110,7 +110,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -146,7 +146,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -175,7 +175,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {

--- a/gitlab/tests/golden/k8s-resources.yml
+++ b/gitlab/tests/golden/k8s-resources.yml
@@ -12,7 +12,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -43,7 +43,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -79,7 +79,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -110,7 +110,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -146,7 +146,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -177,7 +177,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -213,7 +213,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {
@@ -244,7 +244,7 @@
          "echo \"$SSH_CONFIG\" >> ~/.ssh/config"
       ],
       "image": {
-         "name": "docker.io/projectsyn/commodore:v1.34.0"
+         "name": "ghcr.io/projectsyn/commodore:v1.34.0"
       },
       "rules": [
          {


### PR DESCRIPTION
As per decision here: https://kb.vshn.ch/corp-tech/decisions/container-image-location.html#_decision


- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the following labels so it shows up
      in the correct changelog section:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`, `internal`

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
